### PR TITLE
Reduce the number of MQTT messages sent by lite-node

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -664,9 +664,12 @@ func (kl *Kubelet) defaultNodeStatusFuncs() []func(*v1.Node) error {
 	setters = append(setters, nodestatus.VolumeLimits(kl.volumePluginMgr.ListVolumePluginWithLimits))
 
 	setters = append(setters,
+		// DELETE by zhangjie
+		/*
 		nodestatus.MemoryPressureCondition(kl.clock.Now, kl.evictionManager.IsUnderMemoryPressure, kl.recordNodeStatusEvent),
 		nodestatus.DiskPressureCondition(kl.clock.Now, kl.evictionManager.IsUnderDiskPressure, kl.recordNodeStatusEvent),
 		nodestatus.PIDPressureCondition(kl.clock.Now, kl.evictionManager.IsUnderPIDPressure, kl.recordNodeStatusEvent),
+		 */
 
 		nodestatus.ReadyCondition(kl.clock.Now, kl.runtimeState.runtimeErrors, kl.runtimeState.networkErrors, kl.runtimeState.storageErrors, validateHostFunc, kl.containerManager.Status, kl.shutdownManager.ShutdownStatus, kl.recordNodeStatusEvent),
 		nodestatus.VolumesInUse(kl.volumeManager.ReconcilerStatesHasBeenSynced, kl.volumeManager.GetVolumesInUse),

--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -545,6 +545,7 @@ func (kl *Kubelet) tryUpdateNodeStatus(tryNumber int) error {
 		}
 	}
 
+	klog.V(4).Infof("Prepare to patch node status ...")
 	// Patch the current status on the API server
 	updatedNode, _, err := nodeutil.PatchNodeStatus(kl.heartbeatClient.CoreV1(), types.NodeName(kl.nodeName), originalNode, node)
 	if err != nil {

--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -521,6 +521,8 @@ func (kl *Kubelet) tryUpdateNodeStatus(tryNumber int) error {
 	kl.setNodeStatus(node)
 
 	now := kl.clock.Now()
+	// DELETE BY zhangjie, no need user nodeStatusReportFrequency
+	/*
 	if now.Before(kl.lastStatusReportTime.Add(kl.nodeStatusReportFrequency)) {
 		if !podCIDRChanged && !nodeStatusHasChanged(&originalNode.Status, &node.Status) {
 			// We must mark the volumes as ReportedInUse in volume manager's dsw even
@@ -543,6 +545,29 @@ func (kl *Kubelet) tryUpdateNodeStatus(tryNumber int) error {
 			klog.Infof("podCIDRChanged no changed, node status no changed, so do not patch node")
 			return nil
 		}
+	}
+	 */
+
+	if !podCIDRChanged && !nodeStatusHasChanged(&originalNode.Status, &node.Status) {
+		// We must mark the volumes as ReportedInUse in volume manager's dsw even
+		// if no changes were made to the node status (no volumes were added or removed
+		// from the VolumesInUse list).
+		//
+		// The reason is that on a kubelet restart, the volume manager's dsw is
+		// repopulated and the volume ReportedInUse is initialized to false, while the
+		// VolumesInUse list from the Node object still contains the state from the
+		// previous kubelet instantiation.
+		//
+		// Once the volumes are added to the dsw, the ReportedInUse field needs to be
+		// synced from the VolumesInUse list in the Node.Status.
+		//
+		// The MarkVolumesAsReportedInUse() call cannot be performed in dsw directly
+		// because it does not have access to the Node object.
+		// This also cannot be populated on node status manager init because the volume
+		// may not have been added to dsw at that time.
+		kl.volumeManager.MarkVolumesAsReportedInUse(node.Status.VolumesInUse)
+		klog.Infof("podCIDRChanged no changed, node status no changed, so do not patch node")
+		return nil
 	}
 
 	klog.V(4).Infof("Prepare to patch node status ...")

--- a/pkg/openyurt/fileCache/fileObjectDeps.go
+++ b/pkg/openyurt/fileCache/fileObjectDeps.go
@@ -203,6 +203,9 @@ func (f *FilePodDeps) GetFullFileName(obj interface{}) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if len(name) == 0 {
+		return "", fmt.Errorf("can not get filename by object")
+	}
 	return filepath.Join(f.GetDir(), name), nil
 }
 

--- a/pkg/openyurt/message/local_client.go
+++ b/pkg/openyurt/message/local_client.go
@@ -124,7 +124,7 @@ func cleanLocalCache(client mqtt.Client, nodename, rootTopic string) {
 			}
 			cloudMap[filepath.Base(filename)] = struct{}{}
 
-			if err := savePodToObjectFile(tmpPod); err != nil {
+			if err := savePodToObjectFile(tmpPod, nodename); err != nil {
 				klog.Error("Save pod[%s/%s] to object file error %v", tmpPod.GetNamespace(), tmpPod.GetName(), err)
 				continue
 			}

--- a/pkg/openyurt/message/local_client_node.go
+++ b/pkg/openyurt/message/local_client_node.go
@@ -72,6 +72,9 @@ func (n *nodes) Create(ctx context.Context, node *corev1.Node, opts v1.CreateOpt
 }
 
 func (n *nodes) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *corev1.Node, err error) {
+
+	// pkg/kubelet/kubelet_node_status.go tryUpdateNodeStatus
+
 	patchData := PublishPatchData(ObjectTypeNode, true, n.nodename, &corev1.Node{
 		ObjectMeta: v1.ObjectMeta{
 			Name: name,

--- a/pkg/openyurt/message/publish.go
+++ b/pkg/openyurt/message/publish.go
@@ -40,7 +40,6 @@ const (
 	ObjectTypeNode  = "node"
 	ObjectTypePod   = "pod"
 	ObjectTypeStart = "start"
-	ObjectTypeHB    = "heartbeat"
 )
 
 const (
@@ -50,8 +49,6 @@ const (
 	OperateTypeDelete = "delete"
 	OperateTypeGet    = "get"
 	OperateTypeStart  = "start"
-	//OperateTypeOffline = "offline"
-	OperateTypeOnline = "online"
 )
 
 type PublishData struct {
@@ -172,6 +169,3 @@ func PublishStartData(nodename string) *PublishData {
 	return newPublishData(ObjectTypeStart, OperateTypeStart, true, nodename, nil, nil, "", nil, nil)
 }
 
-func PublishOnlineData(nodename string) *PublishData {
-	return newPublishData(ObjectTypeHB, OperateTypeOnline, false, nodename, nil, nil, "", nil, nil)
-}

--- a/pkg/openyurt/message/subcribe_handlers.go
+++ b/pkg/openyurt/message/subcribe_handlers.go
@@ -68,7 +68,7 @@ func dealWithSubcribeDate(client mqtt.Client, rootTopic, nodeName string, subcri
 			}
 		}
 
-		if err := savePodToObjectFile(subcribeData.PodData); err != nil {
+		if err := savePodToObjectFile(subcribeData.PodData, nodeName); err != nil {
 			klog.Errorf("Save pod object to file error %v", err)
 			return err
 		}
@@ -108,7 +108,13 @@ func saveNodeToObjectFile(s *corev1.Node) error {
 	return nil
 }
 
-func savePodToObjectFile(s *corev1.Pod) error {
+func savePodToObjectFile(s *corev1.Pod, nodeName string) error {
+	if s == nil {
+		return nil
+	}
+	if s.Spec.NodeName != nodeName {
+		return fmt.Errorf("pod.spec.nodeName is %s not %s", s.Spec.NodeName, nodeName)
+	}
 
 	dateBytes, err := yaml.Marshal(s)
 	if err != nil {

--- a/pkg/openyurt/oyLeasecontroller/lease_controller.go
+++ b/pkg/openyurt/oyLeasecontroller/lease_controller.go
@@ -31,8 +31,31 @@ type controller struct {
 	nodeName  string
 }
 
+// Run
+// Normally kubelet updates the lease to Apiserver every 10 seconds to maintain the node ready.
+// If the lease heartbeat is sent through MQTT protocol, and the number of hosts is very large, too many heartbeats will be sent every day.
+// Due to the limited ability of kole-controller to consume messages, This may cause message accumulation and the host lease status cannot be updated quickly.
+// Too much news also brings more economic costs.
+
+// The Run method regularly sends heartbeat information to the kole-controller through MQTT
+// and reduces the heartbeat sending time interval.
+// We believe that pod eviction is not required in the lightweight scenario, so it is acceptable to delay the update of host state.
+// Considering the cost and the consumption speed of messages, We temporarily set the heartbeat interval to 5 minutes.
+// But the heartbeat information is not a lease object.
+
+//The kole-controller updates the lease object every 10 seconds instead of the original kubelet lease logic after receiving the heartbeat message .
+// When the kole-controller does not receive the heartbeat message from lite-kubelet within 1.5 x 5 m,
+// it considers that the lite-node is offline and stops updating the lease information.
+
+// After some time, kube-controller-manger determines whether the node is readdy based on the lease update time, This is the original logic of kube-controller-manager
+
+// TODO
+// The MQTT3 protocol supports testamentary mode (Will Message),
+// in which MTQT Brokers send will messages indicating that certain lite-node are offline when they are unexpectedly disconnected, offline, or disconnected from the MQTT broker.
+// In the future, if kole-controller supports the ability to subscribe to wills, lite-kubelet will not need to send heartbeat packets regularly at all,
+// further reducing the number of messages to be sent.
 func (c *controller) Run(stopCh <-chan struct{}) {
-	ticker := time.NewTicker(time.Minute)
+	ticker := time.NewTicker(time.Minute*5)
 	defer func() {
 		ticker.Stop()
 		klog.Errorf("Heartbeat controller stoped ...")

--- a/pkg/openyurt/oyLeasecontroller/lease_controller.go
+++ b/pkg/openyurt/oyLeasecontroller/lease_controller.go
@@ -16,13 +16,9 @@ limitations under the License.
 package oyLeasecontroller
 
 import (
-	"time"
-
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 
 	"k8s.io/component-helpers/apimachinery/lease"
-	"k8s.io/klog/v2"
-	"k8s.io/kubernetes/pkg/openyurt/message"
 )
 
 type controller struct {
@@ -55,6 +51,8 @@ type controller struct {
 // In the future, if kole-controller supports the ability to subscribe to wills, lite-kubelet will not need to send heartbeat packets regularly at all,
 // further reducing the number of messages to be sent.
 func (c *controller) Run(stopCh <-chan struct{}) {
+
+	/*
 	ticker := time.NewTicker(time.Minute*5)
 	defer func() {
 		ticker.Stop()
@@ -85,7 +83,7 @@ func (c *controller) Run(stopCh <-chan struct{}) {
 			return
 		}
 	}
-
+	 */
 }
 
 // NewController constructs and returns a controller


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

In order to reduce the number of MQTT messages lite-Node sends (due to cost and the cloud's ability to consume MQTTS), several adjustments have been made to Kubelet:

- Update nodeStatus periodically: Every 5m, the patch node status is forced。After receiving the MQTT message from the node, the cloud controller considers that the node is online and updates the lease object on behalf of the node。
ref: pkg/kubelet/kubelet_node_status.go  L551

- due to prohibit cadvisor and evictionManager, so IsUnderMemoryPressure IsUnderDiskPressure, IsUnderPIDPressure doesn't work, All false, so the reporting of events is disabled, indirectly reducing MQTT messages
ref: pkg/kubelet/kubelet_node_status.go  L668

- Stop sending heartbeat messages using the lease Controller.
Since nodeStatus forces patch nodestatus every 5 seconds, which is equivalent to replacing heartbeat information, lease Controller can do nothing。

ref: pkg/openyurt/oyLeasecontroller/lease_controller.go

Other modifications:
Before saving the pod declaration file to the local node, check whether pod.spec.nodeName is the local host name. If not, do not save the file to the local node. lite-kubelet caches only nodes on the host.

pkg/openyurt/message/subcribe_handlers.go L111

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
