### PR TITLE
sync node status when lite kubelet startd

### DIFF
--- a/pkg/openyurt/fileCache/file.go
+++ b/pkg/openyurt/fileCache/file.go
@@ -233,7 +233,7 @@ func (s *ObjectSourceFile) produceWatchEvent(e *fsnotify.Event) error {
 		return nil
 	}
 
-	klog.V(4).Infof("produceWatchEvent: name %s, type %s", e.Name, eventType)
+	klog.V(4).Infof("produceWatchEvent: name %s, type %v", e.Name, eventType)
 	s.watchEvents <- &watchFileEvent{e.Name, eventType}
 	return nil
 }

--- a/pkg/openyurt/message/local_client.go
+++ b/pkg/openyurt/message/local_client.go
@@ -150,6 +150,12 @@ func cleanLocalCache(client mqtt.Client, nodename, rootTopic string) {
 				klog.Infof("The pod corresponding to localcache file %s exist in the cloud, so keep the localcache file, do nothing", f)
 			}
 		}
+
+		if err := saveNodeToObjectFile(startdata.Node); err != nil {
+			klog.Errorf("Save Node %s to object file error %v", nodename, err)
+			continue
+		}
+
 		return
 	}
 }

--- a/pkg/openyurt/message/subcribe_handlers.go
+++ b/pkg/openyurt/message/subcribe_handlers.go
@@ -89,7 +89,9 @@ func dealWithSubcribeDate(client mqtt.Client, rootTopic, nodeName string, subcri
 }
 
 func saveNodeToObjectFile(s *corev1.Node) error {
-
+	if s == nil {
+		return nil
+	}
 	dateBytes, err := yaml.Marshal(s)
 	if err != nil {
 		klog.Errorf("Marshal node[%s/%s] to bytes error %v",

--- a/pkg/openyurt/message/subscribe.go
+++ b/pkg/openyurt/message/subscribe.go
@@ -51,6 +51,7 @@ type AckDataStartObject struct {
 	PodsList      []*corev1.Pod       `json:"pods_list,omitempty"`
 	SecretList    []*corev1.Secret    `json:"secret_list,omitempty"`
 	ConfigMapList []*corev1.ConfigMap `json:"config_map_list,omitempty"`
+	Node          *corev1.Node        `json:"node,omitempty"`
 }
 
 func (p *AckData) String() string {


### PR DESCRIPTION
Signed-off-by: kadisi <iamkadisi@163.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
/kind bug



#### What this PR does / why we need it:

when lite-kubelet restart or reconnect with mqtt , it need sync node info from cloud to local cache

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

when lite-kubelet restart or reconnect with mqtt , it need sync node info from cloud to local cache
```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
